### PR TITLE
add dlm snapshot lifecycle rules

### DIFF
--- a/tf/ebs_snapshots.tf
+++ b/tf/ebs_snapshots.tf
@@ -1,0 +1,88 @@
+locals {
+  dlm_interval = 12
+}
+
+resource "aws_iam_role" "dlm_lifecycle_role" {
+  name = "dlm-lifecycle-role"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "dlm.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "dlm_lifecycle" {
+  name = "dlm-lifecycle-policy"
+  role = "${aws_iam_role.dlm_lifecycle_role.id}"
+
+  policy = <<EOF
+{
+   "Version": "2012-10-17",
+   "Statement": [
+      {
+         "Effect": "Allow",
+         "Action": [
+            "ec2:CreateSnapshot",
+            "ec2:DeleteSnapshot",
+            "ec2:DescribeVolumes",
+            "ec2:DescribeSnapshots"
+         ],
+         "Resource": "*"
+      },
+      {
+         "Effect": "Allow",
+         "Action": [
+            "ec2:CreateTags"
+         ],
+         "Resource": "arn:aws:ec2:*::snapshot/*"
+      }
+   ]
+}
+EOF
+}
+
+resource "aws_dlm_lifecycle_policy" "example" {
+  description        = "${var.env_name} DLM lifecycle policy"
+  execution_role_arn = "${aws_iam_role.dlm_lifecycle_role.arn}"
+  state              = "ENABLED"
+
+  policy_details {
+    resource_types = ["VOLUME"]
+
+    schedule {
+      name = "90 days of snapshots"
+
+      create_rule {
+        interval      = "${local.dlm_interval}"
+        interval_unit = "HOURS"
+        times         = ["20:00"]
+      }
+
+      retain_rule {
+        count = "${24 / local.dlm_interval * 90}"
+      }
+
+      tags_to_add = {
+        SnapshotCreator = "DLM"
+      }
+
+      copy_tags = true
+    }
+
+    target_tags = {
+      Name     = "jenkins-master"
+      env_name = "${var.env_name}"
+    }
+  }
+}


### PR DESCRIPTION
Note that vagrant-aws is incapable of setting ebs volume tags upon
instance creation and will require a tag to be manually created in order
for the dlm policy to work.